### PR TITLE
Add Kafka message support for device creation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mv  /build/profiles /root/ && \
      apk update && apk add --no-cache ca-certificates && update-ca-certificates && \
 	apk add --no-cache bash py2-pip wget openssl-dev  python-dev py-openssl && \
 	apk add --no-cache gcc linux-headers musl-dev  py-lxml && \
- 	pip2 install requests flask  lxml zeep
+ 	pip2 install requests flask  lxml zeep kafka
 
 RUN mkdir -p /opt \
  && wget http://downloads.sourceforge.net/project/ejbca/ejbca6/ejbca_6_3_1_1/ejbca_ce_6_3_1_1.zip \
@@ -37,9 +37,7 @@ RUN cd /build/ejbca_ce_6_3_1_1/modules/ejbca-ejb-cli && \
 COPY entrypoint.sh /root/entrypoint.sh
 RUN  mkdir -p /var/www && \
 	chmod +x /root/entrypoint.sh
-COPY *.py  /var/www/
-
-
+ADD . /var/www/
 
 EXPOSE 5583
 CMD ["/root/entrypoint.sh"]

--- a/KafkaMain.py
+++ b/KafkaMain.py
@@ -1,0 +1,96 @@
+# alternatively to the REST API
+# one can use Kafka messages to configure ejbca-rest
+# This file is the EJBCA kafka entry point
+# the purpose of functions here is to verify input and pass
+# the requests to the controller class
+import logging
+import kafka
+import json
+from time import sleep
+import requests
+from threading import Thread
+
+import conf
+from controller.RequestError import RequestError
+import controller.UserController as uc
+from ejbcaUtils import initicalConf
+
+LOGGER = logging.getLogger('ejbca.' + __name__)
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.DEBUG)
+
+
+class KafkaConsumer(Thread):
+    def __init__(self):
+        Thread.__init__(self)
+
+    def run(self):
+        while True:
+            LOGGER.debug("waiting for new messages")
+
+            # To consume latest messages and auto-commit offsets
+            while True:
+                try:
+                    consumer = (kafka.
+                                KafkaConsumer('notifyDeviceChange',
+                                              group_id='ejbca',
+                                              bootstrap_servers=[conf.kafkaHost]
+                                              ))
+                    break
+                except kafka.errors.NoBrokersAvailable:
+                    LOGGER.error('Could not connect to Kafka at %s.'
+                                 ' Chances are the server is not ready yet.'
+                                 ' Will retry in 30sec' % conf.kafkaHost)
+                    sleep(30)
+
+            for message in consumer:
+                try:
+                    requestData = json.loads(message.value)
+                except ValueError:
+                    LOGGER.error('Could not decode message as JSON. '
+                                 + dumpKafkaMessage(message))
+                    continue
+
+                if 'action' not in requestData.keys():
+                    LOGGER.error('Action not specified. '
+                                 + dumpKafkaMessage(message))
+                    continue
+
+                if requestData['action'] in ['create', 'update']:
+                    try:
+                        if 'device' not in requestData.keys():
+                            LOGGER.error("Device name not especified. "
+                                         + dumpKafkaMessage(message))
+                            continue
+                        requestData['username'] = requestData['device']
+                        uc.createOrEditUser(requestData)
+                        LOGGER.info('user %s created' % requestData['device'])
+                    except RequestError as err:
+                        LOGGER.error(err.message + " "
+                                     + dumpKafkaMessage(message))
+
+                elif requestData['action'] == 'delete':
+                    try:
+                        if 'device' not in requestData.keys():
+                            LOGGER.error("Device name not especified. "
+                                         + dumpKafkaMessage(message))
+                            continue
+                        uc.deleteUser(requestData['device'])
+                        LOGGER.info("Device %s revocated"
+                                    % requestData['device'])
+                    except RequestError as err:
+                        LOGGER.error(err.message + " "
+                                     + dumpKafkaMessage(message))
+
+                else:
+                    LOGGER.error("'Action' " + requestData['action']
+                                 + " not implemented"
+                                 + dumpKafkaMessage(message))
+
+    # helper function to log messages (for debug purposes)
+    def dumpKafkaMessage(msg):
+        return ('%s:%d:%d: key=%s value=%s'
+                % (msg.topic, msg.partition,
+                   msg.offset, msg.key,
+                   msg.value)
+                )

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,3 @@
+import os
+
+kafkaHost = os.environ.get("EJBCA_KAFKA_HOST", "kafka:9092")

--- a/controller/RequestError.py
+++ b/controller/RequestError.py
@@ -1,0 +1,7 @@
+# a generic RequestError Exception
+
+
+class RequestError(Exception):
+    def __init__(self, errorCode, message):
+        self.message = message
+        self.errorCode = errorCode

--- a/controller/UserController.py
+++ b/controller/UserController.py
@@ -1,0 +1,36 @@
+import enumList
+import zeep
+import zeep.helpers
+
+from controller.RequestError import RequestError
+from ejbcaUtils import ejbcaServ, initicalConf
+
+
+# create or update a user
+def createOrEditUser(userInfoJson):
+    fillable = ['caName', 'username', 'certificateProfileName', 'clearPwd',
+                'endEntityProfileName', 'keyRecoverable', 'password',
+                'tokenType', 'subjectDN']
+    userData = {k: userInfoJson[k] for k in userInfoJson if k in fillable}
+
+    userData['sendNotification'] = False
+    userData['status'] = 10  # user created. Pending certification
+    userData['keyRecoverable'] = False
+    userData['clearPwd'] = True
+    try:
+        ejbcaServ().editUser(userData)
+    except (zeep.exceptions.Fault, zeep.exceptions.ValidationError) as error:
+        raise RequestError(400, 'soap message: ' + error.message)
+
+
+# revoke all certificates of a user.
+# delete the user if deleteAfter is especified
+def deleteUser(username, reason='UNSPECIFIED', deleteAfter=False):
+    try:
+        reasonCode = enumList.REVOKATION_REASON[reason].value
+    except KeyError:
+        raise RequestError(400, 'invalid revokation reason ' + reason)
+    try:
+        ejbcaServ().revokeUser(username, reasonCode, deleteAfter)
+    except zeep.exceptions.Fault as error:
+        raise RequestError(400, 'soap message: ' + error.message)

--- a/controller/__init__.py
+++ b/controller/__init__.py
@@ -1,0 +1,3 @@
+# python 2 require a init script on sub directories
+import RequestError
+import UserController

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 /opt/jboss-as-7.1.1.Final/bin/standalone.sh -b 127.0.0.1 &
-/var/www/RESTmain.py 
+python /var/www/RESTmain.py


### PR DESCRIPTION
Alternatively to the REST interface, KAFKA messages can be used to configure new devices.
Changed pkcs10Request REST URL so it have a different prefix.
Some PEP8 fixes, to calm down IDE linter warnings.

This PR closes dojot/dojot#154