### PR TITLE
Create a new CRL every day.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,12 @@ RUN cd /build/ejbca_ce_6_3_1_1/modules/ejbca-ejb-cli && \
  	 cd /build/ejbca_ce_6_3_1_1/dist && mv ejbca-ejb-cli /root/ && \
  	 rm -rf /build
 
+COPY ejbca-docker/scripts/createcrl.sh /etc/periodic/daily/createcrl.sh
 COPY entrypoint.sh /root/entrypoint.sh
 RUN  mkdir -p /var/www && \
-	chmod +x /root/entrypoint.sh
+	chmod +x /root/entrypoint.sh && \
+	chmod +x /etc/periodic/daily/createcrl.sh
+
 ADD . /var/www/
 
 EXPOSE 5583

--- a/ejbca-docker/scripts/createcrl.sh
+++ b/ejbca-docker/scripts/createcrl.sh
@@ -1,0 +1,2 @@
+cd /root/ejbca-ejb-cli/
+./ejbca.sh ca createcrl

--- a/ejbcaUtils.py
+++ b/ejbcaUtils.py
@@ -1,7 +1,8 @@
-#this file contain utilitary function to help co-autenticate with ejbca
+# this file contain utilitary function to help co-autenticate with ejbca
 # and configure the ejbcaWSDLbase class
 import OpenSSL.crypto
-import os, stat
+import os
+import stat
 import ssl
 import zeep
 import requests
@@ -9,15 +10,19 @@ import json
 from zeep.transports import Transport
 import zeep.helpers
 
-#the WSDL service class
+
+# the WSDL service class
 global ejbcaWSDLbase
 
-#just and alias
+
+# just an alias
 def ejbcaServ():
     return ejbcaWSDLbase.service
 
+
 def pfx_to_pem(pfx_path, pfx_password):
-    #https://gist.github.com/erikbern/756b1d8df2d1487497d29b90e81f8068
+    # based on
+    # https://gist.github.com/erikbern/756b1d8df2d1487497d29b90e81f8068
     ''' Decrypts the .pfx or .p12 file to be used with requests. '''
     f_pem = open('/p12/superadmin.pem', 'wb')
     pfx = open(pfx_path, 'rb').read()
@@ -31,6 +36,7 @@ def pfx_to_pem(pfx_path, pfx_password):
     f_pem.close()
     os.chmod('/p12/superadmin.pem', stat.S_IRUSR)
 
+
 def retrieveCACert():
     try:
         cert = ejbcaServ().getLastCAChain('IOTmidCA')[0]['certificateData']
@@ -38,10 +44,12 @@ def retrieveCACert():
         print('Error occurred while loading CA cert chain. soap message: ' + error.message)
         exit(-1)
 
-    caCrt = "-----BEGIN CERTIFICATE-----\n" +  cert  + "\n-----END CERTIFICATE-----\n"
+    caCrt = ("-----BEGIN CERTIFICATE-----\n"
+             + cert + "\n-----END CERTIFICATE-----\n")
 
     with open('/p12/ca.crt', "w") as crtFile:
         crtFile.write(caCrt)
+
 
 def loadWSDLbase():
     global ejbcaWSDLbase
@@ -56,8 +64,14 @@ def loadWSDLbase():
 
     ejbcaWSDLbase.options(raw_response=True)
 
+
 def populateProfileDatabase():
     os.system("cd /root/ejbca-ejb-cli && bash ./ejbca.sh ca importprofiles -d /root/profiles")
+
+
+def updateCRL():
+    os.system("/etc/periodic/daily/createcrl.sh")
+
 
 def createSubCA(subCaJSON, parentCAID):
     cmd = "cd /root/ejbca-ejb-cli && bash ejbca.sh ca init --caname " + subCaJSON['name'] + \
@@ -74,7 +88,8 @@ def createSubCA(subCaJSON, parentCAID):
             break
 
     for sub in subCaJSON['subca']:
-        createSubCA(sub,str(caID) )
+        createSubCA(sub, str(caID))
+
 
 def configureCA(cafilePath):
     populateProfileDatabase()
@@ -82,25 +97,28 @@ def configureCA(cafilePath):
         with open(cafilePath) as data_file:
             caJSON = json.load(data_file)
 
-        for caZepp in  zeep.helpers.serialize_object(ejbcaServ().getAvailableCAs()):
+        for caZepp in zeep.helpers.serialize_object(ejbcaServ().getAvailableCAs()):
             if caZepp['name'] == caJSON['name']:
                 caID = caZepp['id']
                 break
 
         for sub in caJSON['subca']:
-            createSubCA(sub, str(caID) )
+            createSubCA(sub, str(caID))
         os.rename(cafilePath, cafilePath + '.bak')
+
 
 def initicalConf():
     if not os.path.isfile('/p12/superadmin.pem'):
         if not os.path.isfile('/p12/superadmin.p12'):
-            print "Client certificate 'superadmin.p12' not found'"
+            print("Client certificate 'superadmin.p12' not found")
             exit(-1)
         pfx_to_pem('/p12/superadmin.p12', 'ejbca')
 
     loadWSDLbase()
     if not os.path.isfile('/p12/ca.crt'):
         retrieveCACert()
-        loadWSDLbase() #if the connection was unsafe, conect again with certificates
+        # if the connection was unsafe, conect again with certificates
+        loadWSDLbase()
 
     configureCA('/root/CAs/caHierarchy.json')
+    updateCRL()


### PR DESCRIPTION
This solve a critical bug where a invalid CRL is served on container first run.
Although this solve the first run outdated CRL problem, more tests is necessary to check if a new CRL is generated every day.

Also, some PEP-8 fixes.

This PR is related to #4 