### PR TITLE
Fix to increase EJBCA's deployment timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,21 @@ COPY requirements/ /requirements
 RUN mv  /build/profiles /root/ && \
 	mv  /build/CAs /root/ && \
 	mv /etc/apk/repositories /etc/apk/repositories.old && \
-	cat /etc/apk/repositories.old | sed -e 's/3.4/3.6/g' > /etc/apk/repositories 
+	cat /etc/apk/repositories.old | sed -e 's/3.4/3.6/g' > /etc/apk/repositories
 
-RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates 
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
 
 RUN apk add --no-cache bash py3-pip wget openssl-dev python3 py-openssl libffi-dev
 
-RUN apk add --no-cache gcc linux-headers musl-dev  py-lxml 
+RUN apk add --no-cache gcc linux-headers musl-dev  py-lxml
 
-RUN python3 -m ensurepip 
+RUN apk add --no-cache xmlstarlet
 
-RUN apk add --no-cache python3-dev 
+RUN python3 -m ensurepip
 
-RUN pip3 uninstall -y pyopenssl 
+RUN apk add --no-cache python3-dev
+
+RUN pip3 uninstall -y pyopenssl
 
 RUN pip3 install -r /requirements/requirements.txt
 
@@ -52,6 +54,9 @@ RUN mkdir -p /var/www && \
 ADD . /var/www/
 
 RUN mkdir -p /data && sed -i 's|~/|/data/|g' /opt/jboss-as-7.1.1.Final/standalone/configuration/standalone.xml
+
+RUN xmlstarlet ed --inplace -N x="urn:jboss:domain:deployment-scanner:1.1" -i '//x:deployment-scanner' \
+      -t attr -n 'deployment-timeout' -v '600' /opt/jboss-as-7.1.1.Final/standalone/configuration/standalone.xml
 
 VOLUME [ "/data" ]
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

On a poorly performing computer, the EJBCA does not rise within the allowed time and a timeout prevents the deployment from being loaded on the EJBCA container application server.

* **What is the new behavior (if this is a feature change)?**

This change aims to increase the timeout so that it is possible for the EJBCA to have enough time to go up on the application server.
I set a time of 10 minutes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

[dojot/dojot/1586](https://app.zenhub.com/workspaces/dojot-ws-5ca7620c263982676581b05d/issues/dojot/dojot/1586)

* **Other information**:

The change had to be made directly in the Dockerfile. If the time is not enough, we can increase it in the Dockerfile, the problem is that this is not easy to change after the docker image has been compiled.
I believe that 10 minutes of timeout is sufficient.